### PR TITLE
Update DelugeVPN image version to 2.1.1-4-01

### DIFF
--- a/stacks/media/resources/deluge.ts
+++ b/stacks/media/resources/deluge.ts
@@ -106,7 +106,7 @@ export class Deluge extends ComponentResource {
         securityContext: {
           privileged: true,
         },
-        image: 'binhex/arch-delugevpn:2.0.5-1-04',
+        image: 'binhex/arch-delugevpn:2.1.1-4-01',
         env: {
           VPN_ENABLED: 'yes',
           VPN_USER: this.args.pia.user,


### PR DESCRIPTION
This commit updates the DelugeVPN Docker image version from 2.0.5-1-04 to 2.1.1-4-01 in the `deluge.ts` file located in the `stacks/media/resources/` directory. The VPN user environment variable is also set using a passed-in argument value.
