### PR TITLE
Add NuGet.Config file with GitHub package source

### DIFF
--- a/.github/workflows/tctl.yml
+++ b/.github/workflows/tctl.yml
@@ -36,10 +36,18 @@ jobs:
       # - run: dotnet test -c Release --no-build
       - run: dotnet pack -c Release --no-build -o out
 
+      - name: Authenticate to GitHub Packages
+        if: github.event_name == 'push' && github.ref_name != 'main'
+        run: |
+          dotnet nuget add source \
+            --username UnstoppableMango \
+            --password ${{ secrets.GITHUB_TOKEN }} \
+            --store-password-in-clear-text \
+            --name github "https://nuget.pkg.github.com/UnstoppableMango/index.json"
+
       - name: Publish to GitHub Packages
         if: github.event_name == 'push' && github.ref_name != 'main'
         run: |
           dotnet nuget push \
             out/UnMango.TheCluster.CLI.*.nupkg \
-            --api-key ${{ secrets.GITHUB_TOKEN }} \
             --source github

--- a/tools/tctl/NuGet.Config
+++ b/tools/tctl/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <add key="github" value="https://nuget.pkg.github.com/UnstoppableMango/index.json" />
+    </packageSources>
+</configuration>


### PR DESCRIPTION
This commit adds a new file, NuGet.Config, to the tools/tctl directory. The NuGet.Config file contains XML configuration for package sources, specifically adding a new package source named "github" with the value "https://nuget.pkg.github.com/UnstoppableMango/index.json".
