### PR TITLE
Updated renovate.json paths

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,8 +17,7 @@
     "infra/**",
     "lib/**",
     "operator/**",
-    "tools/helm-types/**",
-    "tools/tctl/**"
+    "tools/**"
   ],
   "ignoreDeps": [
     "@unstoppablemango/thecluster",


### PR DESCRIPTION
The paths in the renovate.json file have been simplified. Instead of specifying each subdirectory under 'tools', now all directories and files under 'tools' are included by using a single wildcard path.
