### PR TITLE
Disable E2E tests in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,9 @@ jobs:
       - name: Test
         run: make test
 
-      - name: E2e Tests
-        run: make e2e
+      # Let's just not opt into this headache right now
+      # - name: E2e Tests
+      #   run: make e2e
 
       - name: Build thecluster
         run: make bin/thecluster


### PR DESCRIPTION
The end-to-end tests have been commented out in the continuous integration workflow. This change is temporary to avoid current issues with these tests. The build process remains unaffected.

They work tho