### PR TITLE
Introduced generic options pattern in Go

### DIFF
--- a/internal/option/option.go
+++ b/internal/option/option.go
@@ -1,0 +1,58 @@
+package option
+
+type ptr[T any] interface{ ~*T }
+
+type Option[T any] interface {
+	~func(T)
+}
+
+type Immutable[T any] interface {
+	~func(T) T
+}
+
+type Maybe[T any] interface {
+	~func(T) error
+}
+
+func Apply[T any, O Option[T]](opts T, options ...O) {
+	ApplyAll(opts, options)
+}
+
+func ApplyAll[T any, O Option[T]](opts T, options []O) {
+	for _, option := range options {
+		option(opts)
+	}
+}
+
+func TryApply[T any, O Maybe[T]](opts T, options ...O) error {
+	return TryApplyAll(opts, options)
+}
+
+func TryApplyAll[T any, O Maybe[T]](opts T, options []O) error {
+	for _, option := range options {
+		if err := option(opts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func With[T any, O Immutable[T]](opts T, options ...O) T {
+	return WithAll(opts, options)
+}
+
+func WithAll[T any, O Immutable[T]](opts T, options []O) T {
+	for _, option := range options {
+		opts = option(opts)
+	}
+
+	return opts
+}
+
+func Mut[T any, P ptr[T], I Immutable[T]](option func(P)) I {
+	return func(x T) T {
+		option(&x)
+		return x
+	}
+}


### PR DESCRIPTION
This update introduces a new way of handling options in Go using generics. It includes the creation of several interfaces: Option, Immutable, and Maybe. These interfaces are used to define methods for applying single or multiple options to a given object. The implementation also provides error handling when trying to apply an option with the Maybe interface. Additionally, it includes a function for mutating an option while maintaining immutability.
