### PR TITLE
Update renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,9 @@
   "extends": [
     "config:recommended"
   ],
+	"schedule": [
+		"before 4am on the first day of the month"
+	],
   "ignorePaths": [
     "**/node_modules/**",
     "**/vendor/**",


### PR DESCRIPTION
Added a new schedule for Renovate bot to run before 4am on the first day of each month. This will help in keeping dependencies up-to-date with less disruption to daily development activities.
