### PR TITLE
Updates renovate to ignore @pulumi/crds

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,7 @@
 		"lib/**"
 	],
 	"ignoreDeps": [
+		"@pulumi/crds",
 		"@unstoppablemango/thecluster",
 		"@unstoppablemango/thecluster-crds"
 	],


### PR DESCRIPTION
Adds @pulumi/crds to the ignoreDeps list to manage dependencies
more efficiently and prevent unnecessary updates.
