### PR TITLE
Preserves source IPs with MetalLB in NGINX config

### DIFF
--- a/apps/ingress-nginx/index.ts
+++ b/apps/ingress-nginx/index.ts
@@ -31,6 +31,9 @@ const chart = new Chart('ingress-nginx', {
 			admissionWebhooks: {
 				certManager: { enabled: true },
 			},
+			// Preserve source IPs when using MetalLB
+			// https://kubernetes.github.io/ingress-nginx/deploy/baremetal/#a-pure-software-solution-metallb
+			service: { externalTrafficPolicy: 'Local' },
 		},
 	},
 });


### PR DESCRIPTION
Configures externalTrafficPolicy to 'Local' in NGINX chart to
ensure source IP preservation when using MetalLB, improving
network transparency and debugging capabilities.

Relates to Kubernetes NGINX configuration for bare-metal setups.
