### PR TITLE
Updates image sources and tags for dependency consistency

### DIFF
--- a/apps/cert-manager-csi-driver/Pulumi.yaml
+++ b/apps/cert-manager-csi-driver/Pulumi.yaml
@@ -8,9 +8,9 @@ config:
   zoneName: thecluster.io
   versions:
     value:
-      # renovate: datasource=docker depName=jetstack/cert-manager-csi-driver
+      # renovate: datasource=docker depName=quay.io/jetstack/cert-manager-csi-driver
       certManagerCsi: v0.6.0
-      # renovate: datasource=docker depName=sig-storage/csi-node-driver-registrar
+      # renovate: datasource=docker depName=registry.k8s.io/sig-storage/csi-node-driver-registrar
       csiNodeDriverRegistrar: v2.9.2
-      # renovate: datasource=docker depName=sig-storage/livenessprobe
+      # renovate: datasource=docker depName=registry.k8s.io/sig-storage/livenessprobe
       livenessProbe: v2.11.0

--- a/apps/ingress-nginx/Pulumi.yaml
+++ b/apps/ingress-nginx/Pulumi.yaml
@@ -10,7 +10,7 @@ config:
       pulumi:template: typescript
   versions:
     value:
-      # renovate: datasource=docker depName=ingress-nginx/controller
+      # renovate: datasource=docker depName=registry.k8s.io/ingress-nginx/controller
       app: 1.12.3
-      # renovate: datasource=helm depName=kubernetes/ingress-nginx
+      # renovate: datasource=helm depName=https://kubernetes.github.io/ingress-nginx/ingress-nginx
       chart: 4.12.3

--- a/apps/ingress-nginx/index.ts
+++ b/apps/ingress-nginx/index.ts
@@ -26,7 +26,11 @@ const chart = new Chart('ingress-nginx', {
 	namespace: ns.metadata.name,
 	values: {
 		controller: {
-			image: { tag: `v${versions.app}` },
+			image: {
+				registry: 'registry.k8s.io', // default
+				image: 'ingress-nginx/controller', // default
+				tag: `v${versions.app}`,
+			},
 			kind: 'DaemonSet',
 			admissionWebhooks: {
 				certManager: { enabled: true },

--- a/apps/origin-ca-issuer/Pulumi.yaml
+++ b/apps/origin-ca-issuer/Pulumi.yaml
@@ -10,7 +10,7 @@ config:
       pulumi:template: typescript
   versions:
     value:
-      # renovate: datasource=github-tags depName=cloudflare/origin-ca-issuer
-      app: v0.12.1
-      # renovate: datasource=helm depName=cloudflare/origin-ca-issuer-charts
+      # renovate: datasource=docker depName=cloudflare/origin-ca-issuer
+      app: 0.12.1
+      # renovate: datasource=helm depName=oci://ghcr.io/cloudflare/origin-ca-issuer-charts/origin-ca-issuer
       chart: 0.5.12

--- a/apps/origin-ca-issuer/index.ts
+++ b/apps/origin-ca-issuer/index.ts
@@ -17,8 +17,8 @@ const versions = Versions.parse(config.requireObject('versions'));
 
 const crds = new ConfigGroup('crds', {
 	files: [
-		`https://raw.githubusercontent.com/cloudflare/origin-ca-issuer/${versions.app}/deploy/crds/cert-manager.k8s.cloudflare.com_originissuers.yaml`,
-		`https://raw.githubusercontent.com/cloudflare/origin-ca-issuer/${versions.app}/deploy/crds/cert-manager.k8s.cloudflare.com_clusteroriginissuers.yaml`,
+		`https://raw.githubusercontent.com/cloudflare/origin-ca-issuer/v${versions.app}/deploy/crds/cert-manager.k8s.cloudflare.com_originissuers.yaml`,
+		`https://raw.githubusercontent.com/cloudflare/origin-ca-issuer/v${versions.app}/deploy/crds/cert-manager.k8s.cloudflare.com_clusteroriginissuers.yaml`,
 	],
 });
 
@@ -30,9 +30,11 @@ const chart = new Chart('origin-ca-issuer', {
 	chart: 'oci://ghcr.io/cloudflare/origin-ca-issuer-charts/origin-ca-issuer',
 	version: versions.chart,
 	namespace: ns.metadata.name,
+	// https://github.com/cloudflare/origin-ca-issuer/blob/trunk/deploy/charts/origin-ca-issuer/values.yaml
 	values: {
 		controller: {
 			image: {
+				repository: 'cloudflare/origin-ca-issuer', // default
 				tag: versions.app,
 			},
 		},


### PR DESCRIPTION
Refines Docker image sources for cert-manager-csi-driver and
ingress-nginx, shifting to registry.k8s.io for consistency.
Enhances origin-ca-issuer configuration with Docker data source
and modifies CRD URLs for clarity. Ensures image tag usage in
origin-ca-issuer aligns with version parsing.

These changes aim to standardize dependency sources and improve
clarity in referencing specific versions.
