### PR TITLE
Updates cron schedule and removes deprecated initContainers

### DIFF
--- a/apps/renovate/index.ts
+++ b/apps/renovate/index.ts
@@ -61,7 +61,7 @@ const chart = new Chart('renovate', {
 	// https://github.com/renovatebot/helm-charts/blob/main/charts/renovate/values.yaml
 	values: {
 		cronjob: {
-			schedule: '*/5 * * * *', // Every 5 minutes
+			schedule: '0 */12 * * *', // Twice a day, every 5m was probably too greedy
 			timeZone: 'America/Chicago',
 			initContainers: [{
 				name: 'github-app-auth',

--- a/flux/clusters/pinkdiamond/arc-runners/helm-release.yml
+++ b/flux/clusters/pinkdiamond/arc-runners/helm-release.yml
@@ -15,14 +15,6 @@ spec:
     githubConfigSecret: thecluster-bot
     template:
       spec:
-        # https://github.com/actions/actions-runner-controller/issues/2890
-        # initContainers:
-        #   - name: kube-init
-        #     image: ghcr.io/actions/actions-runner:2.328.0
-        #     command: [sudo, chown, -R, 1001:123, /home/runner/_work]
-        #     volumeMounts:
-        #       - name: work
-        #         mountPath: /home/runner/_work
         containers:
           - name: runner
             image: ghcr.io/actions/actions-runner:2.328.0
@@ -46,14 +38,6 @@ spec:
     minRunners: 1 # it's soooo sllooowwwwwww
     template:
       spec:
-        # https://github.com/actions/actions-runner-controller/issues/2890
-        # initContainers:
-        #   - name: kube-init
-        #     image: ghcr.io/actions/actions-runner:2.328.0
-        #     command: [sudo, chown, -R, 1001:123, /home/runner/_work]
-        #     volumeMounts:
-        #       - name: work
-        #         mountPath: /home/runner/_work
         containers:
           - name: runner
             image: ghcr.io/actions/actions-runner:2.328.0


### PR DESCRIPTION
Changes renovate cron job schedule to run twice daily due to
excessive frequency.

Removes commented-out initContainers section from Helm release
configurations, addressing outdated comments related to an
issue in actions-runner-controller.
