### PR TITLE
Adds new repository to renovate configuration

### DIFF
--- a/apps/renovate/index.ts
+++ b/apps/renovate/index.ts
@@ -46,7 +46,10 @@ module.exports = {
 	platform: 'github',
 	autodiscover: false, // default
 	autodiscoverFilter: [], // default
-	repositories: ['UnstoppableMango/the-cluster'],
+	repositories: [
+		'UnstoppableMango/the-cluster',
+		'UnstoppableMango/ux',
+	],
 	presetCachePersistence: true,
 };
 `;


### PR DESCRIPTION
Includes 'UnstoppableMango/ux' repository in the list for
renovation, enabling dependency management for this project
along with 'the-cluster'.
