### PR TITLE
Adds privileged security context to sidecar

### DIFF
--- a/flux/clusters/pinkdiamond/arc-runners/helm-release.yml
+++ b/flux/clusters/pinkdiamond/arc-runners/helm-release.yml
@@ -65,6 +65,8 @@ spec:
             image: docker:28.4.0-dind-rootless
             restartPolicy: Always # sidecar
             command: [ dockerd, --host, tcp://127.0.0.1:2375 ]
+            securityContext:
+              privileged: true
         containers:
           - name: runner # default
             image: ghcr.io/unstoppablemango/the-cluster/actions-runner:sha-0eb8334


### PR DESCRIPTION
Enables privileged mode for the docker sidecar container in the Helm
release configuration to enhance its capabilities for specific
operations requiring additional permissions.
