### PR TITLE
Fixes typo in node affinity setting

### DIFF
--- a/apps/pihole/index.ts
+++ b/apps/pihole/index.ts
@@ -212,7 +212,7 @@ const externalDns = instances.map(({ name }) =>
 				},
 			},
 			affinity: {
-				nodeAfinity: {
+				nodeAffinity: {
 					preferredDuringSchedulingIgnoredDuringExecution: [{
 						weight: 1,
 						preference: {


### PR DESCRIPTION
Corrects a typographical error in the node affinity configuration, ensuring correct spelling of `nodeAffinity`.
