### PR TITLE
Configures Gluetun VPN for media apps

### DIFF
--- a/flux/clusters/pinkdiamond/media/deluge-statefulset.yml
+++ b/flux/clusters/pinkdiamond/media/deluge-statefulset.yml
@@ -83,7 +83,7 @@ spec:
                 command:
                   - "/bin/sh"
                   - "-c"
-                  - "(ip rule del table 51820; ip -6 rule del table 51820) || true"
+                  - "(ip rule del table 51820 2>/dev/null; ip -6 rule del table 51820 2>/dev/null) || true"
           volumeMounts:
             - name: vpn-config
               mountPath: /gluetun/wireguard

--- a/flux/clusters/pinkdiamond/media/deluge-statefulset.yml
+++ b/flux/clusters/pinkdiamond/media/deluge-statefulset.yml
@@ -64,6 +64,9 @@ spec:
               value: custom
             - name: VPN_TYPE
               value: wireguard
+            # https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/firewall.md
+            - name: FIREWALL_OUTBOUND_SUBNETS
+              value: 10.42.0.0/16,10.43.0.0/16
           resources:
             requests:
               cpu: 10m

--- a/flux/clusters/pinkdiamond/media/deluge-statefulset.yml
+++ b/flux/clusters/pinkdiamond/media/deluge-statefulset.yml
@@ -67,6 +67,8 @@ spec:
             # https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/firewall.md
             - name: FIREWALL_OUTBOUND_SUBNETS
               value: 10.42.0.0/16,10.43.0.0/16
+            - name: FIREWALL_INPUT_PORTS
+              value: 8112,6881,58846
           resources:
             requests:
               cpu: 10m

--- a/flux/clusters/pinkdiamond/media/deluge-statefulset.yml
+++ b/flux/clusters/pinkdiamond/media/deluge-statefulset.yml
@@ -76,6 +76,14 @@ spec:
             limits:
               cpu: 500m
               memory: 128Mi
+          # https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/kubernetes.md
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - "/bin/sh"
+                  - "-c"
+                  - "(ip rule del table 51820; ip -6 rule del table 51820) || true"
           volumeMounts:
             - name: vpn-config
               mountPath: /gluetun/wireguard

--- a/flux/clusters/pinkdiamond/media/qbittorrent-statefulset.yml
+++ b/flux/clusters/pinkdiamond/media/qbittorrent-statefulset.yml
@@ -83,7 +83,7 @@ spec:
                 command:
                   - "/bin/sh"
                   - "-c"
-                  - "(ip rule del table 51820; ip -6 rule del table 51820) || true"
+                  - "(ip rule del table 51820 2>/dev/null; ip -6 rule del table 51820 2>/dev/null) || true"
           volumeMounts:
             - name: vpn-config
               mountPath: /gluetun/wireguard

--- a/flux/clusters/pinkdiamond/media/qbittorrent-statefulset.yml
+++ b/flux/clusters/pinkdiamond/media/qbittorrent-statefulset.yml
@@ -64,6 +64,9 @@ spec:
               value: custom
             - name: VPN_TYPE
               value: wireguard
+            # https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/firewall.md
+            - name: FIREWALL_OUTBOUND_SUBNETS
+              value: 10.42.0.0/16,10.43.0.0/16
           resources:
             requests:
               cpu: 10m

--- a/flux/clusters/pinkdiamond/media/qbittorrent-statefulset.yml
+++ b/flux/clusters/pinkdiamond/media/qbittorrent-statefulset.yml
@@ -67,6 +67,8 @@ spec:
             # https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/firewall.md
             - name: FIREWALL_OUTBOUND_SUBNETS
               value: 10.42.0.0/16,10.43.0.0/16
+            - name: FIREWALL_INPUT_PORTS
+              value: 8080,6881
           resources:
             requests:
               cpu: 10m

--- a/flux/clusters/pinkdiamond/media/qbittorrent-statefulset.yml
+++ b/flux/clusters/pinkdiamond/media/qbittorrent-statefulset.yml
@@ -76,6 +76,14 @@ spec:
             limits:
               cpu: 500m
               memory: 128Mi
+          # https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/kubernetes.md
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - "/bin/sh"
+                  - "-c"
+                  - "(ip rule del table 51820; ip -6 rule del table 51820) || true"
           volumeMounts:
             - name: vpn-config
               mountPath: /gluetun/wireguard


### PR DESCRIPTION
Adds essential configuration for Gluetun VPN-backed media applications, Deluge and qBittorrent.

- Configures the VPN firewall to allow necessary inbound ports for torrenting clients and their web UIs.
- Restricts outbound VPN traffic to specified cluster subnets, enhancing network security and preventing unintended external access.
- Implements a `postStart` lifecycle hook to ensure proper cleanup of IP routing rules, addressing potential routing conflicts and improving VPN stability within the Kubernetes environment.