### PR TITLE
Configures ndots:1 for improved DNS resolution

### DIFF
--- a/flux/clusters/pinkdiamond/media/deluge-statefulset.yml
+++ b/flux/clusters/pinkdiamond/media/deluge-statefulset.yml
@@ -14,6 +14,10 @@ spec:
       labels:
         app.kubernetes.io/name: deluge
     spec:
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
       initContainers:
         - name: generate-vpn-config
           image: ghcr.io/unstoppablemango/pia-manual-connections:v0.2.2-pia2026-01-30r0

--- a/flux/clusters/pinkdiamond/media/qbittorrent-statefulset.yml
+++ b/flux/clusters/pinkdiamond/media/qbittorrent-statefulset.yml
@@ -14,6 +14,10 @@ spec:
       labels:
         app.kubernetes.io/name: qbittorrent
     spec:
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
       initContainers:
         - name: generate-vpn-config
           image: ghcr.io/unstoppablemango/pia-manual-connections:v0.2.2-pia2026-01-30r0


### PR DESCRIPTION
Adds the `ndots:1` option to pod DNS configurations for Deluge and qBittorrent.

This optimizes DNS lookups by preventing unnecessary search suffix appending for single-label hostnames, which can occur in certain container environments and lead to resolution delays or failures. This improves reliability and performance for internal service communication.
