### PR TITLE
Deploys trust-manager for CA bundle management

### DIFF
--- a/flux/clusters/pinkdiamond/cert-manager/trust-manager.yml
+++ b/flux/clusters/pinkdiamond/cert-manager/trust-manager.yml
@@ -1,0 +1,43 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: trust-manager
+  namespace: cert-manager
+spec:
+  interval: 30m
+  releaseName: trust-manager
+  targetNamespace: cert-manager
+  chart:
+    spec:
+      chart: trust-manager
+      version: v0.22.0
+      sourceRef:
+        kind: HelmRepository
+        name: jetstack
+  # https://github.com/cert-manager/trust-manager/tree/main/deploy/charts/trust-manager
+  values:
+    image:
+      repository: quay.io/jetstack/trust-manager
+      tag: v0.22.0
+    defaultPackage:
+      enabled: false
+    resources:
+      requests:
+        cpu: 25m
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+---
+apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: thecluster-lan-ca
+spec:
+  sources:
+    - secret:
+        name: "thecluster.lan"
+        key: tls.crt
+  target:
+    configMap:
+      key: ca.crt


### PR DESCRIPTION
Installs the trust-manager Helm chart, which automates the distribution of CA certificates within the cluster.

Configures a Bundle resource to propagate the `thecluster.lan` CA certificate from a secret into a ConfigMap, making it available for other services to consume. Sets resource limits and disables the default certificate package.
