### PR TITLE
Unifies CA certificate distribution

### DIFF
--- a/flux/clusters/pinkdiamond/cert-manager/trust-manager.yml
+++ b/flux/clusters/pinkdiamond/cert-manager/trust-manager.yml
@@ -28,3 +28,16 @@ spec:
       limits:
         cpu: 100m
         memory: 128Mi
+---
+apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: thecluster-lan-ca
+spec:
+  sources:
+    - secret:
+        name: "thecluster.lan"
+        key: tls.crt
+  target:
+    configMap:
+      key: ca.crt

--- a/flux/clusters/pinkdiamond/coredns-system/coredns-helm-release.yml
+++ b/flux/clusters/pinkdiamond/coredns-system/coredns-helm-release.yml
@@ -41,7 +41,7 @@ spec:
               stubzones
               path /skydns
               endpoint https://etcd.coredns-system.svc.cluster.local:2379
-              tls /etc/coredns/etcd-client-tls/tls.crt /etc/coredns/etcd-client-tls/tls.key /etc/coredns/etcd-client-tls/ca.crt
+              tls /etc/coredns/etcd-client-tls/tls.crt /etc/coredns/etcd-client-tls/tls.key /etc/coredns/ca/ca.crt
           - name: cache
             parameters: "30"
           - name: loop
@@ -67,9 +67,15 @@ spec:
       - name: etcd-client-tls
         secret:
           secretName: etcd-client-tls
+      - name: ca
+        configMap:
+          name: thecluster-lan-ca
     extraVolumeMounts:
       - name: etcd-client-tls
         mountPath: /etc/coredns/etcd-client-tls
+        readOnly: true
+      - name: ca
+        mountPath: /etc/coredns/ca
         readOnly: true
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
@@ -115,7 +121,7 @@ spec:
               stubzones
               path /skydns
               endpoint https://etcd.coredns-system.svc.cluster.local:2379
-              tls /etc/coredns/etcd-client-tls/tls.crt /etc/coredns/etcd-client-tls/tls.key /etc/coredns/etcd-client-tls/ca.crt
+              tls /etc/coredns/etcd-client-tls/tls.crt /etc/coredns/etcd-client-tls/tls.key /etc/coredns/ca/ca.crt
           - name: cache
             parameters: "30"
           - name: loop
@@ -141,7 +147,13 @@ spec:
       - name: etcd-client-tls
         secret:
           secretName: etcd-client-tls
+      - name: ca
+        configMap:
+          name: thecluster-lan-ca
     extraVolumeMounts:
       - name: etcd-client-tls
         mountPath: /etc/coredns/etcd-client-tls
+        readOnly: true
+      - name: ca
+        mountPath: /etc/coredns/ca
         readOnly: true

--- a/flux/clusters/pinkdiamond/coredns-system/external-dns-helm-release.yml
+++ b/flux/clusters/pinkdiamond/coredns-system/external-dns-helm-release.yml
@@ -39,14 +39,20 @@ spec:
       - name: ETCD_KEY_FILE
         value: /etc/external-dns/etcd-client-tls/tls.key
       - name: ETCD_TRUSTED_CA_FILE
-        value: /etc/external-dns/etcd-client-tls/ca.crt
+        value: /etc/external-dns/ca/ca.crt
     extraVolumes:
       - name: etcd-client-tls
         secret:
           secretName: etcd-client-tls
+      - name: ca
+        configMap:
+          name: thecluster-lan-ca
     extraVolumeMounts:
       - name: etcd-client-tls
         mountPath: /etc/external-dns/etcd-client-tls
+        readOnly: true
+      - name: ca
+        mountPath: /etc/external-dns/ca
         readOnly: true
     resources:
       requests:


### PR DESCRIPTION
Unifies CA certificate distribution for core services.

This re-introduces a `trust-manager` Bundle resource to automate the sourcing of CA certificates from a designated secret and propagate them to a ConfigMap. This centralizes and simplifies how core services, such as CoreDNS, consume the necessary CA trust.

The change reverts a previous removal, indicating that the required Custom Resource Definitions (CRDs) are now available to support this functionality.