### PR TITLE
Renames etcd CA file variable for ExternalDNS

### DIFF
--- a/flux/clusters/pinkdiamond/coredns-system/external-dns-helm-release.yml
+++ b/flux/clusters/pinkdiamond/coredns-system/external-dns-helm-release.yml
@@ -38,7 +38,7 @@ spec:
         value: /etc/external-dns/etcd-client-tls/tls.crt
       - name: ETCD_KEY_FILE
         value: /etc/external-dns/etcd-client-tls/tls.key
-      - name: ETCD_TRUSTED_CA_FILE
+      - name: ETCD_CA_FILE
         value: /etc/external-dns/ca/ca.crt
     extraVolumes:
       - name: etcd-client-tls


### PR DESCRIPTION
Standardizes the environment variable name for the etcd client CA certificate file path. Changes `ETCD_TRUSTED_CA_FILE` to `ETCD_CA_FILE` for clarity and consistency with ExternalDNS's etcd client configuration.
