### PR TITLE
Adds per-component Kustomization CRs following flux example repo structure

### DIFF
--- a/flux/clusters/pinkdiamond/infrastructure.yaml
+++ b/flux/clusters/pinkdiamond/infrastructure.yaml
@@ -10,7 +10,6 @@ spec:
   path: ./flux/infrastructure/controllers
   interval: 10m
   prune: true
-  wait: true
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -24,5 +23,4 @@ spec:
   path: ./flux/infrastructure/configs
   interval: 10m
   prune: true
-  dependsOn:
-    - name: infra-controllers
+  wait: true

--- a/flux/infrastructure/configs/cert-manager.yaml
+++ b/flux/infrastructure/configs/cert-manager.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-configs-cert-manager
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./flux/infrastructure/configs/cert-manager
+  interval: 10m
+  prune: true
+  wait: true
+  dependsOn:
+    - name: infra-cert-manager

--- a/flux/infrastructure/configs/cloudflare-operator.yaml
+++ b/flux/infrastructure/configs/cloudflare-operator.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-configs-cloudflare-operator
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./flux/infrastructure/configs/cloudflare-operator-system
+  interval: 10m
+  prune: true
+  dependsOn:
+    - name: infra-cloudflare-operator

--- a/flux/infrastructure/configs/cloudflare.yaml
+++ b/flux/infrastructure/configs/cloudflare.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-configs-cloudflare
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./flux/infrastructure/configs/cloudflare-system
+  interval: 10m
+  prune: true
+  dependsOn:
+    - name: infra-cloudflare

--- a/flux/infrastructure/configs/coredns.yaml
+++ b/flux/infrastructure/configs/coredns.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-configs-coredns
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./flux/infrastructure/configs/coredns-system
+  interval: 10m
+  prune: true
+  wait: true
+  dependsOn:
+    - name: infra-configs-cert-manager

--- a/flux/infrastructure/configs/kustomization.yaml
+++ b/flux/infrastructure/configs/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cert-manager.yaml
+  - cloudflare-operator.yaml
+  - cloudflare.yaml
+  - coredns.yaml
+  - metallb.yaml
+  - nginx-gateway.yaml

--- a/flux/infrastructure/configs/metallb.yaml
+++ b/flux/infrastructure/configs/metallb.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-configs-metallb
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./flux/infrastructure/configs/metallb-system
+  interval: 10m
+  prune: true
+  dependsOn:
+    - name: infra-metallb

--- a/flux/infrastructure/configs/nginx-gateway.yaml
+++ b/flux/infrastructure/configs/nginx-gateway.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-configs-nginx-gateway
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./flux/infrastructure/configs/nginx-gateway
+  interval: 10m
+  prune: true
+  wait: true
+  dependsOn:
+    - name: infra-configs-cert-manager

--- a/flux/infrastructure/controllers/arc-system.yaml
+++ b/flux/infrastructure/controllers/arc-system.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-arc-system
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./flux/infrastructure/controllers/arc-system
+  interval: 10m
+  prune: true
+  wait: true

--- a/flux/infrastructure/controllers/cert-manager.yaml
+++ b/flux/infrastructure/controllers/cert-manager.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-cert-manager
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./flux/infrastructure/controllers/cert-manager
+  interval: 10m
+  prune: true
+  wait: true

--- a/flux/infrastructure/controllers/cloudflare-operator.yaml
+++ b/flux/infrastructure/controllers/cloudflare-operator.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-cloudflare-operator
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./flux/infrastructure/controllers/cloudflare-operator-system
+  interval: 10m
+  prune: true
+  wait: true

--- a/flux/infrastructure/controllers/cloudflare.yaml
+++ b/flux/infrastructure/controllers/cloudflare.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-cloudflare
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./flux/infrastructure/controllers/cloudflare-system
+  interval: 10m
+  prune: true
+  wait: true

--- a/flux/infrastructure/controllers/cnpg.yaml
+++ b/flux/infrastructure/controllers/cnpg.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-cnpg
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./flux/infrastructure/controllers/cnpg-system
+  interval: 10m
+  prune: true
+  wait: true

--- a/flux/infrastructure/controllers/coredns.yaml
+++ b/flux/infrastructure/controllers/coredns.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-coredns
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./flux/infrastructure/controllers/coredns-system
+  interval: 10m
+  prune: true
+  wait: true
+  dependsOn:
+    - name: infra-configs-coredns

--- a/flux/infrastructure/controllers/crossplane.yaml
+++ b/flux/infrastructure/controllers/crossplane.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-crossplane
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./flux/infrastructure/controllers/crossplane-system
+  interval: 10m
+  prune: true
+  wait: true

--- a/flux/infrastructure/controllers/flux.yaml
+++ b/flux/infrastructure/controllers/flux.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-flux
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./flux/infrastructure/controllers/flux-system
+  interval: 10m
+  prune: true
+  wait: true

--- a/flux/infrastructure/controllers/kustomization.yaml
+++ b/flux/infrastructure/controllers/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - arc-system.yaml
+  - cert-manager.yaml
+  - cloudflare-operator.yaml
+  - cloudflare.yaml
+  - cnpg.yaml
+  - coredns.yaml
+  - crossplane.yaml
+  - flux.yaml
+  - metallb.yaml
+  - metrics-server.yaml
+  - nats.yaml
+  - nginx-gateway.yaml
+  - velero.yaml

--- a/flux/infrastructure/controllers/metallb.yaml
+++ b/flux/infrastructure/controllers/metallb.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-metallb
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./flux/infrastructure/controllers/metallb-system
+  interval: 10m
+  prune: true
+  wait: true

--- a/flux/infrastructure/controllers/metrics-server.yaml
+++ b/flux/infrastructure/controllers/metrics-server.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-metrics-server
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./flux/infrastructure/controllers/metrics-server
+  interval: 10m
+  prune: true
+  wait: true

--- a/flux/infrastructure/controllers/nats.yaml
+++ b/flux/infrastructure/controllers/nats.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-nats
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./flux/infrastructure/controllers/nats-system
+  interval: 10m
+  prune: true
+  wait: true

--- a/flux/infrastructure/controllers/nginx-gateway.yaml
+++ b/flux/infrastructure/controllers/nginx-gateway.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-nginx-gateway
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./flux/infrastructure/controllers/nginx-gateway
+  interval: 10m
+  prune: true
+  wait: true
+  dependsOn:
+    - name: infra-configs-nginx-gateway

--- a/flux/infrastructure/controllers/velero.yaml
+++ b/flux/infrastructure/controllers/velero.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-velero
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./flux/infrastructure/controllers/velero-system
+  interval: 10m
+  prune: true
+  wait: true


### PR DESCRIPTION
Each infrastructure component now has its own Kustomization CR under
controllers/ and configs/ with explicit dependsOn chains to handle
ordering: cert-manager → configs-cert-manager → configs-nginx-gateway
→ nginx-gateway, and similarly for coredns/etcd TLS dependency.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
