### PR TITLE
Adds namespace manifests to configs layers for nginx-gateway and coredns

### DIFF
--- a/flux/infrastructure/configs/coredns-system/namespace.yml
+++ b/flux/infrastructure/configs/coredns-system/namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: coredns-system

--- a/flux/infrastructure/configs/nginx-gateway/namespace.yml
+++ b/flux/infrastructure/configs/nginx-gateway/namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nginx-gateway


### PR DESCRIPTION
The configs Kustomizations create Certificates in these namespaces, but
the namespaces were previously created by HelmReleases in the controllers
layer (which depends on configs). Adding Namespace resources to the configs
directories breaks the circular dependency.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
