### PR TITLE
Applies fsGroup to media torrent clients

### DIFF
--- a/flux/apps/media/deluge-statefulset.yml
+++ b/flux/apps/media/deluge-statefulset.yml
@@ -14,6 +14,8 @@ spec:
       labels:
         app.kubernetes.io/name: deluge
     spec:
+      securityContext:
+        fsGroup: 1000
       dnsConfig:
         options:
           - name: ndots

--- a/flux/apps/media/qbittorrent-statefulset.yml
+++ b/flux/apps/media/qbittorrent-statefulset.yml
@@ -14,6 +14,8 @@ spec:
       labels:
         app.kubernetes.io/name: qbittorrent
     spec:
+      securityContext:
+        fsGroup: 1000
       dnsConfig:
         options:
           - name: ndots


### PR DESCRIPTION
Sets the fsGroup to 1000 in the pod security context for Deluge
and qBittorrent. This ensures proper file permissions on mounted
volumes, resolving potential access issues for the applications
when interacting with their download and data directories.
