### PR TITLE
Prevents `re.sub` misinterpretation in qBittorrent

### DIFF
--- a/flux/apps/media/qbittorrent-statefulset.yml
+++ b/flux/apps/media/qbittorrent-statefulset.yml
@@ -59,7 +59,7 @@ spec:
               if config_path.exists():
                   text = config_path.read_text()
                   if 'Password_PBKDF2' in text:
-                      text = re.sub(r'WebUI.Password_PBKDF2=.*', line, text)
+                      text = re.sub(r'WebUI.Password_PBKDF2=.*', lambda _: line, text)
                   elif '[Preferences]' in text:
                       text = text.replace('[Preferences]', '[Preferences]\n' + line, 1)
                   else:


### PR DESCRIPTION
Updates the `re.sub` call to use a lambda function for replacement. This ensures that the replacement string is inserted literally without any special character interpretation, preventing unintended modifications to the `WebUI.Password_PBKDF2` field.
