### PR TITLE
Installs Cloudflare operator CRDs separately

### DIFF
--- a/flux/infrastructure/controllers/cloudflare-operator-system/flux-kustomization.yml
+++ b/flux/infrastructure/controllers/cloudflare-operator-system/flux-kustomization.yml
@@ -1,6 +1,20 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  name: cloudflare-operator-crds
+  namespace: cloudflare-operator-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: cloudflare-operator
+  path: ./config/crd/bases
+  interval: 30m
+  prune: false
+  wait: true
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
   name: cloudflare-operator
   namespace: cloudflare-operator-system
 spec:
@@ -12,6 +26,8 @@ spec:
   prune: true
   targetNamespace: cloudflare-operator-system
   wait: true
+  dependsOn:
+    - name: cloudflare-operator-crds
   images:
     - name: controller
       newName: adyanth/cloudflare-operator

--- a/flux/infrastructure/controllers/cloudflare-system/flux-kustomization.yml
+++ b/flux/infrastructure/controllers/cloudflare-system/flux-kustomization.yml
@@ -9,5 +9,5 @@ spec:
     name: origin-ca-issuer
   path: ./deploy/crds
   interval: 1h
-  prune: true
-  targetNamespace: cloudflare-system
+  prune: false
+  wait: true


### PR DESCRIPTION
Separates the deployment of Cloudflare operator Custom Resource Definitions (CRDs) into a dedicated Kustomization.

Ensures CRDs are installed and available in the cluster before the main Cloudflare operator application is deployed, preventing potential startup issues.
