### PR TITLE
Aligns tunnel binding API version

### DIFF
--- a/flux/infrastructure/configs/default/api-server-tunnel-binding.yml
+++ b/flux/infrastructure/configs/default/api-server-tunnel-binding.yml
@@ -1,4 +1,4 @@
-apiVersion: networking.cfargotunnel.com/v1alpha2
+apiVersion: networking.cfargotunnel.com/v1alpha1
 kind: TunnelBinding
 metadata:
   name: api-server


### PR DESCRIPTION
Ensures the API server tunnel binding resource configuration uses the currently supported `apiVersion`. This prevents potential compatibility issues and ensures the resource is correctly interpreted.
