### PR TITLE
Adds cluster-admin service account

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,4 +86,3 @@ yarn.lock: package.json
 
 .envrc: hack/example.envrc
 	cp $< $@
-

--- a/flux/infrastructure/configs/default/cluster-admin-public.yml
+++ b/flux/infrastructure/configs/default/cluster-admin-public.yml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-admin-public
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-admin-public
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: cluster-admin-public
+    namespace: kube-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-admin-public-token
+  namespace: kube-system
+  annotations:
+    kubernetes.io/service-account-name: cluster-admin-public
+type: kubernetes.io/service-account-token

--- a/flux/infrastructure/configs/default/kustomization.yaml
+++ b/flux/infrastructure/configs/default/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - api-server-tunnel-binding.yml
+  - cluster-admin-public.yml


### PR DESCRIPTION
Provisions a dedicated Kubernetes ServiceAccount with cluster-admin ClusterRoleBinding.
This facilitates administrative access for external components or tools needing full control of the cluster.
