### PR TITLE
Relocates `cluster-admin-public` to `kube-system` configs

### DIFF
--- a/flux/infrastructure/configs/kube-system/cluster-admin-public.yml
+++ b/flux/infrastructure/configs/kube-system/cluster-admin-public.yml
@@ -23,5 +23,5 @@ metadata:
   name: cluster-admin-public-token
   namespace: kube-system
   annotations:
-    kubernetes.io/service-account-name: cluster-admin-public
+    kubernetes.io/service-account.name: cluster-admin-public
 type: kubernetes.io/service-account-token

--- a/flux/infrastructure/configs/kube-system/kustomization.yaml
+++ b/flux/infrastructure/configs/kube-system/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - api-server-tunnel-binding.yml
+  - cluster-admin-public.yml

--- a/flux/infrastructure/configs/kustomizations.yaml
+++ b/flux/infrastructure/configs/kustomizations.yaml
@@ -78,6 +78,19 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  name: infra-configs-kube-system
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./flux/infrastructure/configs/kube-system
+  interval: 10m
+  prune: true
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
   name: infra-configs-default
   namespace: flux-system
 spec:


### PR DESCRIPTION
Moves the `cluster-admin-public` secret generation and its kustomization to a new `kube-system` specific configuration directory. This improves the logical grouping of infrastructure resources, separating `kube-system` components from general `default` configurations.

A new Flux Kustomization is introduced to deploy the `kube-system` configurations.

Corrects the `kubernetes.io/service-account-name` annotation to `kubernetes.io/service-account.name` within the `cluster-admin-public` manifest for updated syntax compliance.
