### PR TITLE
Integrates Cloudflare Provider & Refines Security

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,8 @@ Cross-stack references use `@unstoppablemango/thecluster` (from `lib/nodejs/`) t
 
 Flux manifests live in `flux/clusters/`. Sealed Secrets are used for sensitive data — generate with `make flux/<name>-sealed.yml`.
 
+When a Flux manifest requires a Secret, always create a stub under `hack/secrets/` mirroring the path of the sealed secret (e.g. `hack/secrets/infrastructure/configs/crossplane-system/cloudflare-credentials.yml`). Use `stringData` with empty values so the user can populate and seal it. Never commit real credentials.
+
 ### Workspaces
 
 Root `package.json` defines Yarn workspaces: `apps/*`, `clusters/*`, `components/*`, `infra/*`, `crds`, `lib/nodejs`. Run `yarn install` from the root to install all dependencies.

--- a/flux/infrastructure/configs/kube-system/cluster-admin-public.yml
+++ b/flux/infrastructure/configs/kube-system/cluster-admin-public.yml
@@ -3,6 +3,7 @@ kind: ServiceAccount
 metadata:
   name: cluster-admin-public
   namespace: kube-system
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/flux/infrastructure/controllers/crossplane-system/helm-release.yml
+++ b/flux/infrastructure/controllers/crossplane-system/helm-release.yml
@@ -26,3 +26,4 @@ spec:
         - xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v2.0.0
         - xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v2.0.0
         - xpkg.crossplane.io/crossplane-contrib/provider-keycloak:v2.6.0
+        - xpkg.upbound.io/upbound/provider-upjet-cloudflare:v1.3.0


### PR DESCRIPTION
Integrates the Upbound Cloudflare Upjet provider into Crossplane.
- Enables the management of Cloudflare resources through Crossplane, expanding infrastructure automation capabilities.

Enhances security and developer experience by:
- Adding guidance for Flux secret stubbing, ensuring sensitive data like credentials are never committed directly.
- Disabling service account token automount for the `cluster-admin-public` service account, improving overall security posture.