### PR TITLE
Adds cloudflared k8s proxy helper

### DIFF
--- a/hack/cloudflared-k8s-proxy.service
+++ b/hack/cloudflared-k8s-proxy.service
@@ -1,10 +1,9 @@
 [Unit]
 Description=Cloudflare Access proxy for k8s.thecluster.io
-After=network-online.target
-Wants=network-online.target
 
 [Service]
 Type=simple
+Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
 ExecStart=cloudflared access tcp --hostname k8s.thecluster.io --url localhost:16443
 Restart=on-failure
 RestartSec=5

--- a/hack/cloudflared-k8s-proxy.service
+++ b/hack/cloudflared-k8s-proxy.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Cloudflare Access proxy for k8s.thecluster.io
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=cloudflared access tcp --hostname k8s.thecluster.io --url localhost:16443
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/hack/install-cloudflared-k8s-proxy.sh
+++ b/hack/install-cloudflared-k8s-proxy.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -ex
+
+UNIT_NAME=cloudflared-k8s-proxy.service
+UNIT_SRC="$(dirname "$0")/$UNIT_NAME"
+UNIT_DST="$HOME/.config/systemd/user/$UNIT_NAME"
+
+mkdir -p "$(dirname "$UNIT_DST")"
+cp "$UNIT_SRC" "$UNIT_DST"
+
+systemctl --user daemon-reload
+systemctl --user enable --now "$UNIT_NAME"
+
+echo "Proxy running on localhost:16443"
+echo "Authenticate with: cloudflared access login k8s.thecluster.io"


### PR DESCRIPTION
Provides a systemd user service and an installation script to automate setting up a `cloudflared` proxy.
This enables secure local access to Kubernetes (e.g., `k8s.thecluster.io`) through Cloudflare Access, forwarding to `localhost:16443`.
