### PR TITLE
Adds dedicated Cloudflare Crossplane provider

### DIFF
--- a/flux/infrastructure/controllers/crossplane-system/helm-release.yml
+++ b/flux/infrastructure/controllers/crossplane-system/helm-release.yml
@@ -26,4 +26,3 @@ spec:
         - xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v2.0.0
         - xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v2.0.0
         - xpkg.crossplane.io/crossplane-contrib/provider-keycloak:v2.6.0
-        - xpkg.upbound.io/upbound/provider-upjet-cloudflare:v1.3.0

--- a/flux/infrastructure/controllers/crossplane-system/kustomization.yaml
+++ b/flux/infrastructure/controllers/crossplane-system/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - helm-release.yml
   - helm-repository.yml
   - namespace.yml
+  - providers.yml

--- a/flux/infrastructure/controllers/crossplane-system/providers.yml
+++ b/flux/infrastructure/controllers/crossplane-system/providers.yml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-upjet-cloudflare
+spec:
+  package: xpkg.upbound.io/upbound/provider-upjet-cloudflare:v1.3.0


### PR DESCRIPTION
Extracts the Cloudflare provider package from the main Crossplane HelmRelease configuration. Manages the provider as a standalone Provider resource, enabling more modular deployment and independent lifecycle management.
