### PR TITLE
Fix the cloudflare upjet provider package

### DIFF
--- a/flux/infrastructure/controllers/crossplane-system/providers.yml
+++ b/flux/infrastructure/controllers/crossplane-system/providers.yml
@@ -3,4 +3,4 @@ kind: Provider
 metadata:
   name: provider-upjet-cloudflare
 spec:
-  package: xpkg.upbound.io/upbound/provider-upjet-cloudflare:v1.3.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-upjet-cloudflare:v0.1.0


### PR DESCRIPTION
This won't ultimately resolve the problem, because it doesn't look like the provider is actually currently being pushed anywhere.
However, it does now at least follow the install.yaml: https://github.com/crossplane-contrib/provider-upjet-cloudflare/blob/main/examples/install.yaml
