### PR TITLE
Removes external-dns CRD dependency

### DIFF
--- a/flux/infrastructure/controllers/coredns-system/external-dns-helm-release.yml
+++ b/flux/infrastructure/controllers/coredns-system/external-dns-helm-release.yml
@@ -7,8 +7,6 @@ spec:
   interval: 10m
   releaseName: external-dns
   targetNamespace: coredns-system
-  dependsOn:
-    - name: external-dns-crds
   chart:
     spec:
       chart: external-dns


### PR DESCRIPTION
Removes the explicit `dependsOn` entry for `external-dns-crds` from the ExternalDNS HelmRelease.
This streamlines the reconciliation process, as CRDs are now managed independently.
