### PR TITLE
Configures Renovate to ignore additional CRDs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,9 @@
 		"charts/**",
 		"clusters/**",
 		"crds/**",
-		"lib/**"
+		"infra/crds/**",
+		"lib/**",
+		"flux/**/crds/**"
 	],
 	"ignoreDeps": [
 		"@pulumi/crds",


### PR DESCRIPTION
Expands Renovate's `ignorePaths` to exclude Custom Resource Definition (CRD) files within `infra/crds` and `flux/*/crds` paths. This prevents Renovate from attempting to manage or update dependencies in these likely generated or externally managed manifests, improving update stability and relevance.
