### PR TITLE
Fix OLM v1 nodeSelector for k3s control-plane nodes

### DIFF
--- a/flux/infrastructure/controllers/olmv1-system/helm-release.yml
+++ b/flux/infrastructure/controllers/olmv1-system/helm-release.yml
@@ -15,3 +15,10 @@ spec:
         kind: GitRepository
         name: operator-controller
   # https://github.com/operator-framework/operator-controller/blob/v1.8.0/helm/olmv1/values.yaml
+  values:
+    deployments:
+      templateSpec:
+        # k3s sets node-role.kubernetes.io/control-plane=true; chart default expects empty string
+        nodeSelector:
+          kubernetes.io/os: linux
+          node-role.kubernetes.io/control-plane: "true"


### PR DESCRIPTION
k3s labels control-plane nodes with node-role.kubernetes.io/control-plane=true
but the chart default expects an empty string value, causing pods to stay Pending.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
