### PR TITLE
Enable cert-manager for OLM v1 metrics TLS

### DIFF
--- a/flux/infrastructure/controllers/olmv1-system/helm-release.yml
+++ b/flux/infrastructure/controllers/olmv1-system/helm-release.yml
@@ -17,6 +17,8 @@ spec:
   # https://github.com/operator-framework/operator-controller/blob/v1.8.0/helm/olmv1/values.yaml
   values:
     options:
+      certManager:
+        enabled: true
       operatorController:
         deployment:
           image: quay.io/operator-framework/operator-controller:v1.8.0


### PR DESCRIPTION
metrics-bind-address=:8443 requires TLS; enabling certManager provisions
certs via cert-manager and passes --tls-cert/--tls-key to both containers.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
