### PR TITLE
feat: Deploy rook-ceph operator to rosequartz

### DIFF
--- a/clusters/rosequartz/infrastructure.yaml
+++ b/clusters/rosequartz/infrastructure.yaml
@@ -85,3 +85,17 @@ spec:
   interval: 10m
   prune: true
   wait: true
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-rook-ceph
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./infrastructure/controllers/rook-ceph
+  interval: 10m
+  prune: true
+  wait: true


### PR DESCRIPTION
## Summary
- Wires the `infra-rook-ceph` Kustomization (operator only: namespace, HelmRepository, HelmRelease) for rosequartz, following the existing per-controller Flux pattern.
- No CephCluster/configs Kustomization yet — mon store recovery from the old pinkdiamond cluster (zeus/castor mon backups) needs to happen first before a CephCluster CR is applied.

## Test plan
- [ ] `flux get kustomizations` shows `infra-rook-ceph` reconciled successfully on rosequartz
- [ ] `rook-ceph` namespace created, operator pod Running
- [ ] No CephCluster exists yet (expected)